### PR TITLE
Sort playlist items by date added, before downloading

### DIFF
--- a/zotify/playlist.py
+++ b/zotify/playlist.py
@@ -1,7 +1,7 @@
 from zotify.const import ITEMS, ID, TRACK, NAME
 from zotify.termoutput import Printer
 from zotify.track import download_track
-from zotify.utils import split_input
+from zotify.utils import split_input, strptime_utc
 from zotify.zotify import Zotify
 
 MY_PLAYLISTS_URL = 'https://api.spotify.com/v1/me/playlists'
@@ -36,6 +36,8 @@ def get_playlist_songs(playlist_id):
         songs.extend(resp[ITEMS])
         if len(resp[ITEMS]) < limit:
             break
+
+    songs.sort(key=lambda s: strptime_utc(s['added_at']), reverse=True)
 
     return songs
 

--- a/zotify/track.py
+++ b/zotify/track.py
@@ -274,7 +274,7 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                     Printer.print(PrintChannel.DOWNLOADS, f'###   Downloaded "{song_name}" to "{Path(filename).relative_to(Zotify.CONFIG.get_root_path())}" in {fmt_seconds(time_downloaded - time_start)} (plus {fmt_seconds(time_finished - time_downloaded)} converting)   ###' + "\n")
 
                     # add song id to archive file
-                    if Zotify.CONFIG.get_skip_previously_downloaded():
+                    if not check_all_time:
                         add_to_archive(scraped_song_id, PurePath(filename).name, artists[0], name)
                     # add song id to download directory's .song_ids file
                     if not check_id:

--- a/zotify/track.py
+++ b/zotify/track.py
@@ -274,7 +274,7 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                     Printer.print(PrintChannel.DOWNLOADS, f'###   Downloaded "{song_name}" to "{Path(filename).relative_to(Zotify.CONFIG.get_root_path())}" in {fmt_seconds(time_downloaded - time_start)} (plus {fmt_seconds(time_finished - time_downloaded)} converting)   ###' + "\n")
 
                     # add song id to archive file
-                    if not check_all_time:
+                    if Zotify.CONFIG.get_skip_previously_downloaded():
                         add_to_archive(scraped_song_id, PurePath(filename).name, artists[0], name)
                     # add song id to download directory's .song_ids file
                     if not check_id:

--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -282,3 +282,7 @@ def fmt_seconds(secs: float) -> str:
         return f'{m}'.zfill(2) + ':' + f'{s}'.zfill(2)
     else:
         return f'{h}'.zfill(2) + ':' + f'{m}'.zfill(2) + ':' + f'{s}'.zfill(2)
+
+def strptime_utc(dtstr):
+    return datetime.datetime.strptime(dtstr[:-1], '%Y-%m-%dT%H:%M:%S').replace(tzinfo=datetime.timezone.utc)
+


### PR DESCRIPTION
Songs should be downloaded by newest first.
This avoids the long wait of checking and skipping previously downloaded tracks.

When a playlist has had songs added to it since the last download, those songs can be quickly downloaded, and the process manually terminated as soon the existing songs are reached.