### PR TITLE
Effective libopus support

### DIFF
--- a/zotify/const.py
+++ b/zotify/const.py
@@ -110,6 +110,6 @@ EXT_MAP = {
     'm4a': 'm4a',
     'mp3': 'mp3',
     'ogg': 'ogg',
-    'opus': 'ogg',
+    'opus': 'opus',
     'vorbis': 'ogg',
 }

--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -19,6 +19,7 @@ from zotify.zotify import Zotify
 class MusicFormat(str, Enum):
     MP3 = 'mp3',
     OGG = 'ogg',
+    OPUS = 'opus'
 
 
 def create_download_directory(download_path: str) -> None:


### PR DESCRIPTION
Changes to how bitrates and file formats are handled in the program to allow for an appropriate bitrate in the Opus codec, 192K is equal to MP3 320K so loads of space savings. An Opus file is about half the size of the default OGG.

It struck me after digging through the code for a bit that chances are it is in fact using the libopus codec, however with how bitrates are handled it's encoded at 320K. As I previously mentioned, 320K can be reduced to 192K with Opus without noticeable quality degradation. This bitrate reduction resolves into a final file size reduction of almost 50%.

I also included an extra printout just to inform the user as to the codec being used, it would've saved me some time when making this PR so I take that as meaning it's a useful feature to have.

Regarding the changes to `zotify/utils.py`, I'm not 100% sure if that's necessary but for the sake of one line...

_This is my first time contributing to a project, so forgive me if I've missed important details. I'm happy to have my first contribute to a tool I use!_