### PR TITLE
Allow Spotify URL with country code (`intl-xx`)

### DIFF
--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -158,42 +158,42 @@ def regex_input_for_urls(search_input) -> Tuple[str, str, str, str, str, str]:
     track_uri_search = re.search(
         r'^spotify:track:(?P<TrackID>[0-9a-zA-Z]{22})$', search_input)
     track_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/track/(?P<TrackID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w+)?/track/(?P<TrackID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 
     album_uri_search = re.search(
         r'^spotify:album:(?P<AlbumID>[0-9a-zA-Z]{22})$', search_input)
     album_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/album/(?P<AlbumID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w\w)?/album/(?P<AlbumID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 
     playlist_uri_search = re.search(
         r'^spotify:playlist:(?P<PlaylistID>[0-9a-zA-Z]{22})$', search_input)
     playlist_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/playlist/(?P<PlaylistID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w\w)?/playlist/(?P<PlaylistID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 
     episode_uri_search = re.search(
         r'^spotify:episode:(?P<EpisodeID>[0-9a-zA-Z]{22})$', search_input)
     episode_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/episode/(?P<EpisodeID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w\w)?/episode/(?P<EpisodeID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 
     show_uri_search = re.search(
         r'^spotify:show:(?P<ShowID>[0-9a-zA-Z]{22})$', search_input)
     show_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/show/(?P<ShowID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w\w)?/show/(?P<ShowID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 
     artist_uri_search = re.search(
         r'^spotify:artist:(?P<ArtistID>[0-9a-zA-Z]{22})$', search_input)
     artist_url_search = re.search(
-        r'^(https?://)?open\.spotify\.com/artist/(?P<ArtistID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
+        r'^(https?://)?open\.spotify\.com(?:/intl-\w\w)?/artist/(?P<ArtistID>[0-9a-zA-Z]{22})(\?si=.+?)?$',
         search_input,
     )
 


### PR DESCRIPTION
Spotify URLs can have a country code in them, like this: `open.spotify.com/intl-fr/album/<id>` (instead of `open.spotify.com/album/<id>`). Both URLs are working and refere to the same content despite the country code `/intl-xx`. I couldn't find any official documentation about it, I'm guessing it's added to URLs for accounts localized outside USA ? I'm in France and I have it on my browser client, on every page (artists, tracks, etc). I also found [an issue (fixed) about this on the spotDL repo](https://github.com/spotDL/spotify-downloader/issues/1819), and also [someone from Deutshland referring to this on Reddit](https://www.reddit.com/r/rateyourmusic/comments/16jbkac/why_is_every_spotify_url_i_submit_invalid/).

I guess it's to make content (un)available per country.

Anyway I added a small part to ignore `intl-xx` in the Spotify URL RegExp, to be able to just paste URLs without manually edit them every time.