### PR TITLE
Added an option to change artist delimiter character

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Be aware you have to set boolean values in the commandline like this: `--downloa
 | ROOT_PODCAST_PATH            | --root-podcast-path              |          | Directory where Zotify saves podcasts
 | SPLIT_ALBUM_DISCS            | --split-album-discs              | False    | Saves each disk in its own folder
 | DOWNLOAD_LYRICS              | --download-lyrics                | True     | Downloads synced lyrics in .lrc format, uses unsynced as fallback.
+| MD_ARTISTDELIMITER           | --md-artistdelimiter             | ', '     | Delimiter character used to split artists in metadata
 | MD_ALLGENRES                 | --md-allgenres                   | False    | Save all relevant genres in metadata
-| MD_GENREDELIMITER            | --md-genredelimiter              | ,        | Delimiter character used to split genres in metadata
+| MD_GENREDELIMITER            | --md-genredelimiter              | ', '     | Delimiter character used to split genres in metadata
 | DOWNLOAD_FORMAT              | --download-format                | ogg      | The download audio format (aac, fdk_aac, m4a, mp3, ogg, opus, vorbis)
 | DOWNLOAD_QUALITY             | --download-quality               | auto     | Audio quality of downloaded songs (normal, high, very_high*)
 | TRANSCODE_BITRATE            | --transcode-bitrate              | auto     | Overwrite the bitrate for ffmpeg encoding

--- a/zotify/config.py
+++ b/zotify/config.py
@@ -28,6 +28,7 @@ PRINT_ERRORS = 'PRINT_ERRORS'
 PRINT_DOWNLOADS = 'PRINT_DOWNLOADS'
 PRINT_API_ERRORS = 'PRINT_API_ERRORS'
 TEMP_DOWNLOAD_DIR = 'TEMP_DOWNLOAD_DIR'
+MD_ARTISTDELIMITER = 'MD_ARTISTDELIMITER'
 MD_SAVE_GENRES = 'MD_SAVE_GENRES'
 MD_ALLGENRES = 'MD_ALLGENRES'
 MD_GENREDELIMITER = 'MD_GENREDELIMITER'
@@ -46,9 +47,10 @@ CONFIG_VALUES = {
     ROOT_PODCAST_PATH:          { 'default': '',      'type': str,  'arg': '--root-podcast-path'          },
     SPLIT_ALBUM_DISCS:          { 'default': 'False', 'type': bool, 'arg': '--split-album-discs'          },
     DOWNLOAD_LYRICS:            { 'default': 'True',  'type': bool, 'arg': '--download-lyrics'            },
+    MD_ARTISTDELIMITER:         { 'default': ', ',    'type': str,  'arg': '--md-artistdelimiter'         },
     MD_SAVE_GENRES:             { 'default': 'False', 'type': bool, 'arg': '--md-save-genres'             },
     MD_ALLGENRES:               { 'default': 'False', 'type': bool, 'arg': '--md-allgenres'               },
-    MD_GENREDELIMITER:          { 'default': ',',     'type': str,  'arg': '--md-genredelimiter'          },
+    MD_GENREDELIMITER:          { 'default': ', ',    'type': str,  'arg': '--md-genredelimiter'          },
     DOWNLOAD_FORMAT:            { 'default': 'ogg',   'type': str,  'arg': '--download-format'            },
     DOWNLOAD_QUALITY:           { 'default': 'auto',  'type': str,  'arg': '--download-quality'           },
     TRANSCODE_BITRATE:          { 'default': 'auto',  'type': str,  'arg': '--transcode-bitrate'          },
@@ -261,6 +263,10 @@ class Config:
             return ''
         return PurePath(cls.get_root_path()).joinpath(cls.get(TEMP_DOWNLOAD_DIR))
 
+    @classmethod
+    def get_artist_delimiter(cls) -> bool:
+        return cls.get(MD_ARTISTDELIMITER)
+    
     @classmethod
     def get_save_genres(cls) -> bool:
         return cls.get(MD_SAVE_GENRES)

--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -142,7 +142,7 @@ def set_audio_tags(filename, artists, genres, name, album_name, release_year, di
 
 def conv_artist_format(artists) -> str:
     """ Returns converted artist format """
-    return ', '.join(artists)
+    return '/'.join(artists)
 
 
 def set_music_thumbnail(filename, image_url) -> None:

--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -142,7 +142,7 @@ def set_audio_tags(filename, artists, genres, name, album_name, release_year, di
 
 def conv_artist_format(artists) -> str:
     """ Returns converted artist format """
-    return '/'.join(artists)
+    return Zotify.CONFIG.get_artist_delimiter().join(artists)
 
 
 def set_music_thumbnail(filename, image_url) -> None:


### PR DESCRIPTION
As noted in the official ID3 tag documentation
https://id3.org/id3v2.3.0

> TPE1
> The 'Lead artist(s)/Lead performer(s)/Soloist(s)/Performing group' is used for the main artist(s). They are seperated with the "/" character. 