### PR TITLE
fix FromAsCasing warning message when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.9-alpine as base
+FROM python:3.9-alpine AS base
 
 RUN apk --update add ffmpeg
 
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /install
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
Certain keyword should be all caps to avoid warning messages when building docker images. `FROM` and `AS` being two of them. 