### PR TITLE
Add download real time feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# STILL IN DEVELOPMENT, EVERYTHING HERE IS SUBJECT TO CHANGE!
+# STILL IN DEVELOPMENT, EVERYTHING HERE IS SUBJECT TO CHANGE
 
 ## v1.0.0
 
@@ -83,7 +83,6 @@
 - Removed the following config options due to their corresponding features being removed:
   - `bulk_wait_time`
   - `chunk_size`
-  - `download_real_time`
   - `md_allgenres`
   - `md_genredelimiter`
   - `metadata_delimiter`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # Zotify
 
+This is a fork of Zotify's [dev branch](https://github.com/zotify-dev/zotify/tree/v1.0-dev) which hasn't seen any activity for months. This fork will be updated to include missing/unimplemented features and maintained by yours truly until the original developers decide to come home with the milk.
+
 A customizable music and podcast downloader. \
 Formerly ZSp‌otify.
 
-Available on [zotify.xyz](https://zotify.xyz/zotify/zotify) and [GitHub](https://github.com/zotify-dev/zotify). \
 Built on [Librespot](https://github.com/kokarare1212/librespot-python).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Downloads specified items. Accepts any combination of track, album, playlist, ep
 
 ### Basic options
 
-```
+```text
     -p,  --playlist         Download selection of user's saved playlists
     -lt, --liked-tracks     Download user's liked tracks
     -le, --liked-episodes   Download user's liked episodes

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Downloads specified items. Accepts any combination of track, album, playlist, ep
 | output_playlist_episode | --output-playlist-episode | File layout for episodes in a playlist              | {playlist}/{playlist_number}. {episode_number} - {title}   |
 | output_podcast          | --output-podcast          | File layout for saved podcasts                      | {podcast}/{episode_number} - {title}                       |
 | download_quality        | --download-quality        | Audio download quality (auto for highest available) |                                                            |
+| download_real_time      | --download-real-time      | Downloads songs as fast as they would be played     |                                                            |
 | audio_format            | --audio-format            | Audio format of final track output                  |                                                            |
 | transcode_bitrate       | --transcode-bitrate       | Transcoding bitrate (-1 to use download rate)       |                                                            |
 | ffmpeg_path             | --ffmpeg-path             | Path to ffmpeg binary                               |                                                            |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Downloads specified items. Accepts any combination of track, album, playlist, ep
 | ffmpeg_path             | --ffmpeg-path             | Path to ffmpeg binary                               |                                                            |
 | ffmpeg_args             | --ffmpeg-args             | Additional ffmpeg arguments when transcoding        |                                                            |
 | save_credentials        | --save-credentials        | Save login credentials to a file                    |                                                            |
+| replace_existing        | --replace-existing        | Redownload and replace songs if they already exist  |                                                            |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requires Python 3.11 or greater. \
 Optionally requires FFmpeg to save tracks as anything other than Ogg Vorbis.
 
 Enter the following command in terminal to install Zotify. \
-`python -m pip install https://get.zotify.xyz`
+`python -m pip install git+https://github.com/KDalu/zotify.git`
 
 ## General Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built on [Librespot](https://github.com/kokarare1212/librespot-python).
 
 Requires Python 3.11 or greater. \
 Optionally requires FFmpeg to save tracks as anything other than Ogg Vorbis.
+(FFmpeg installation instructions available [here](https://github.com/KDalu/zotify/blob/main/INSTALLATION.md))
 
 Enter the following command in terminal to install Zotify. \
 `python -m pip install git+https://github.com/KDalu/zotify.git`

--- a/zotify/__main__.py
+++ b/zotify/__main__.py
@@ -103,7 +103,6 @@ def main():
             parser.add_argument(
                 *v["args"],
                 action=OptionalOrFalse,
-                default=v["default"],
                 help=v["help"],
             )
         else:

--- a/zotify/app.py
+++ b/zotify/app.py
@@ -267,9 +267,10 @@ class App:
                 track.metadata.extend(playable.metadata)
                 try:
                     output = track.create_output(
+                        self.__config.audio_format.value.ext,
                         playable.library,
                         playable.output_template,
-                        self.__config.replace_existing,
+                        self.__config.replace_existing
                     )
                 except FileExistsError:
                     Logger.log(

--- a/zotify/app.py
+++ b/zotify/app.py
@@ -283,7 +283,7 @@ class App:
                     desc=f"({count}/{total}) {track.name}",
                     total=track.input_stream.size,
                 ) as p_bar:
-                    file = track.write_audio_stream(output, p_bar)
+                    file = track.write_audio_stream(output, p_bar, self.__config.download_real_time)
 
                 # Download lyrics
                 if playable.type == PlayableType.TRACK and self.__config.lyrics_file:

--- a/zotify/app.py
+++ b/zotify/app.py
@@ -250,9 +250,16 @@ class App:
                 # Get track data
                 if playable.type == PlayableType.TRACK:
                     with Loader("Fetching track..."):
-                        track = self.__session.get_track(
-                            playable.id, self.__config.download_quality
-                        )
+                        try:
+                            track = self.__session.get_track(
+                                playable.id, self.__config.download_quality
+                            )
+                        except RuntimeError as err:
+                            Logger.log(
+                                LogChannel.SKIPS,
+                                f'Skipping song id = {playable.id}: {err}',
+                            )
+                            continue
                 elif playable.type == PlayableType.EPISODE:
                     with Loader("Fetching episode..."):
                         track = self.__session.get_episode(playable.id)

--- a/zotify/collections.py
+++ b/zotify/collections.py
@@ -106,6 +106,9 @@ class Playlist(Collection):
                         metadata,
                     )
                 )
+            elif playable_type == "local":
+                # Ignore local files
+                pass
             else:
                 raise ValueError("Unknown playable content", playable_type)
 

--- a/zotify/config.py
+++ b/zotify/config.py
@@ -14,6 +14,7 @@ AUDIO_FORMAT = "audio_format"
 CREATE_PLAYLIST_FILE = "create_playlist_file"
 CREDENTIALS_PATH = "credentials_path"
 DOWNLOAD_QUALITY = "download_quality"
+DOWNLOAD_REAL_TIME = "download_real_time"
 FFMPEG_ARGS = "ffmpeg_args"
 FFMPEG_PATH = "ffmpeg_path"
 LANGUAGE = "language"
@@ -128,6 +129,12 @@ CONFIG_VALUES = {
         "choices": list(Quality),
         "args": ["--download-quality"],
         "help": "Audio download quality (auto for highest available)",
+    },
+    DOWNLOAD_REAL_TIME: {
+        "default": False,
+        "type": bool,
+        "args": ["--download-real-time"],
+        "help": "Download at the same rate as the track being played",
     },
     ARTWORK_SIZE: {
         "default": "large",
@@ -261,6 +268,7 @@ class Config:
     audio_format: AudioFormat
     credentials_path: Path
     download_quality: Quality
+    download_real_time: bool
     ffmpeg_args: str
     ffmpeg_path: str
     language: str

--- a/zotify/playable.py
+++ b/zotify/playable.py
@@ -65,6 +65,7 @@ class Playable:
 
     def create_output(
         self,
+        ext: str,
         library: Path | str = Path("./"),
         output: str = "{title}",
         replace: bool = False,
@@ -86,7 +87,7 @@ class Playable:
                     "{" + meta.name + "}", fix_filename(meta.string)
                 )
         file_path = library.joinpath(output).expanduser()
-        if file_path.exists() and not replace:
+        if file_path.with_suffix("." + ext).exists() and not replace:
             raise FileExistsError("File already downloaded")
         else:
             file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/zotify/playable.py
+++ b/zotify/playable.py
@@ -215,6 +215,8 @@ class Track(PlayableContentFeeder.LoadedStream, Playable):
         """
         if not isinstance(output, Path):
             output = Path(output).expanduser()
+        if not real_time:
+            return super().write_audio_stream(output)
         file = f"{output}.ogg"
         time_start = time()
         downloaded = 0
@@ -223,12 +225,11 @@ class Track(PlayableContentFeeder.LoadedStream, Playable):
             while chunk != b"":
                 chunk = self.input_stream.stream().read(1024)
                 p_bar.update(f.write(chunk))
-                if real_time:
-                    downloaded += len(chunk)
-                    delta_current = time() - time_start
-                    delta_required = (downloaded / self.input_stream.size) * (self.duration/1000)
-                    if delta_required > delta_current:
-                        sleep(delta_required - delta_current)
+                downloaded += len(chunk)
+                delta_current = time() - time_start
+                delta_required = (downloaded / self.input_stream.size) * (self.duration/1000)
+                if delta_required > delta_current:
+                    sleep(delta_required - delta_current)
         return LocalFile(Path(file), AudioFormat.VORBIS)
 
 


### PR DESCRIPTION
Added download real time feature back and included a bug fix regarding config.json values of type bool being ignored/overridden to defaults

This line populates bool type parameters to defaults unless specified in CLI:
https://github.com/zotify-dev/zotify/blob/b11ecfa61a73de27e043b14a3db65752e922690c/zotify/__main__.py#L106

This makes the following line always true for bool type parameters:
https://github.com/zotify-dev/zotify/blob/b11ecfa61a73de27e043b14a3db65752e922690c/zotify/config.py#L303

This shouldn't be the case since the program should check config.json for parameters not specified in CLI before falling back to defaults. This is already properly handled in Config class
https://github.com/zotify-dev/zotify/blob/b11ecfa61a73de27e043b14a3db65752e922690c/zotify/config.py#L301
```
        for key in CONFIG_VALUES:
            # Override config with commandline arguments
            if args is not None and key in vars(args) and vars(args)[key] is not None:
                setattr(self, key, self.__parse_arg_value(key, vars(args)[key]))
            # If no command option specified use config
            elif key in jsonvalues:
                setattr(self, key, self.__parse_arg_value(key, jsonvalues[key]))
            # Use default values for missing keys
            else:
                setattr(
                    self,
                    key,
                    self.__parse_arg_value(key, CONFIG_VALUES[key]["default"]),
                )
```

The line in main.py was unneccessary and was therefore removed